### PR TITLE
Add nodejs 5.x support for Debian systems

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,7 +1,18 @@
 ---
 - name: Configure Debian repo version.
+  when: "'4' in nodejs_version"
   set_fact:
-    debian_repo_version: "{{ nodejs_version if '4' not in nodejs_version else '4.x' }}"
+    debian_repo_version: "4.x"
+    
+- name: Configure Debian repo version.
+  when: "'5' in nodejs_version"
+  set_fact:
+    debian_repo_version: "5.x"
+    
+- name: Configure Debian repo version.
+  when: "'4' not in nodejs_version and '5' not in nodejs_version"
+  set_fact:
+    debian_repo_version: "{{ nodejs_version }}"
 
 - name: Add Nodesource apt key.
   apt_key:
@@ -17,4 +28,4 @@
     - "deb-src https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main"
 
 - name: Ensure Node.js and npm are installed.
-  apt: "name=nodejs={{ nodejs_version }}* state=present update_cache=yes"
+  apt: "name=nodejs={{ nodejs_version|regex_replace('x', '') }}* state=present update_cache=yes"


### PR DESCRIPTION
This allows pinning to either the 4.x or 5.x trees of NodeJS on Debian systems, rather than just the 4.x tree. Due to nodesource/distributions#33 it is impossible to lock down to a specific version within these trees (thus, currently, setting `nodejs_version = "5.x"` will install `nodejs=5.6.0` in APT).