### PR TITLE
Create global install dir 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ script:
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm node -v'
 
   # Ensure npm packages are installed globally.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm npm list -g --depth=0 jslint'
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm npm list -g --depth=0 node-sass'
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm npm list -g --depth=0 yo'
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm bash --login -c "npm list -g --depth=0 jslint"'
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm bash --login -c "npm list -g --depth=0 node-sass"'
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm bash --login -c "npm list -g --depth=0 yo"'
 
   # Clean up
   - 'sudo docker stop "$(cat ${container_id})"'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ The Node.js version to install. "0.10" is the default and works on all supported
 
     nodejs_install_npm_user: "{{ ansible_ssh_user }}"
 
-The user for whom the npm packages will be installed can be set here, this defaults to ansible_ssh_user
+The user for whom the npm packages will be installed can be set here, this defaults to ansible_user
+
+    npm_config_prefix: "~/.npm-global"
+
+The global installation directory. This should be writeable by the nodejs_install_npm_user.
+
+    npm_config_unsafe_perm: "false"
+
+Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail.
 
     nodejs_npm_global_packages: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,12 @@ nodejs_version: "0.12"
 # The user for whom the npm packages will be installed.
 # nodejs_install_npm_user: username
 
+# The directory for global installations.
+npm_config_prefix: "~/.npm-global"
+
+# Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail.
+npm_config_unsafe_perm: "false"
+
 # Define a list of global packages to be installed with NPM.
 nodejs_npm_global_packages: []
 #  # Install a specific version of a package.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,27 +7,44 @@
 
 - name: Define nodejs_install_npm_user
   set_fact:
-    nodejs_install_npm_user: "{{ ansible_ssh_user }}"
+    nodejs_install_npm_user: "{{ ansible_user }}"
   when: nodejs_install_npm_user is not defined
+
+- name: Create npm global directory
+  file:
+    path: "{{ npm_config_prefix }}"
+    owner: "{{ nodejs_install_npm_user }}"
+    group: "{{ nodejs_install_npm_user }}"
+    state: directory
+
+- name: Add npm_config_prefix bin directory to global $PATH.
+  template:
+    src: npm.sh.j2
+    dest: /etc/profile.d/npm.sh
+    mode: 0644
 
 # TODO: Remove this task after Ansible 2.x npm module bug is fixed. See:
 # https://github.com/ansible/ansible-modules-extras/issues/1375
 - name: Ensure npm global packages are installed.
   npm:
     name: "{{ item.name }}"
-    version: "{{ item.version | default('') }}"
+    version: "{{ item.version | default('latest') }}"
     global: yes
     state: present
-  become: yes
-  become_user: "{{ nodejs_install_npm_user }}"
+  environment:
+    NPM_CONFIG_PREFIX: "{{ npm_config_prefix }}"
+    NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
+    NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
   with_items: "{{ nodejs_npm_global_packages }}"
 
 - name: Ensure npm global packages are at the latest release.
   npm:
     name: "{{ item.name }}"
-    version: "{{ item.version | default('') }}"
+    version: "{{ item.version | default('latest') }}"
     global: yes
     state: latest
-  become: yes
-  become_user: "{{ nodejs_install_npm_user }}"
+  environment:
+    NPM_CONFIG_PREFIX: "{{ npm_config_prefix }}"
+    NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
+    NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
   with_items: "{{ nodejs_npm_global_packages }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,6 +14,11 @@
   with_items:
     - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
     - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+  register: node_repo
+
+- name: Update apt cache if repo was added.
+  apt: update_cache=yes
+  when: node_repo.changed
 
 - name: Ensure Node.js and npm are installed.
-  apt: "name=nodejs={{ nodejs_version|regex_replace('x', '') }}* state=present update_cache=yes"
+  apt: "name=nodejs={{ nodejs_version|regex_replace('x', '') }}* state=present"

--- a/templates/npm.sh.j2
+++ b/templates/npm.sh.j2
@@ -1,0 +1,3 @@
+export PATH={{ npm_config_prefix }}/bin:$PATH
+export NPM_CONFIG_PREFIX={{ npm_config_prefix }}
+export NODE_PATH=$NODE_PATH:{{ npm_config_prefix }}/lib/node_modules

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,8 @@
   vars:
     nodejs_version: "5.x"
     nodejs_install_npm_user: root
+    npm_config_prefix: /root/.npm-global
+    npm_config_unsafe_perm: "true"
     nodejs_npm_global_packages:
       - name: node-sass
       - name: jslint


### PR DESCRIPTION
This PR will install NPM allowing installation of global packages without root access, which is recommended based on Option 2 -- https://docs.npmjs.com/getting-started/fixing-npm-permissions

Option 1 would require changing permissions of `/usr`.

Should help resolve https://github.com/geerlingguy/drupal-vm/issues/629 & https://github.com/beetboxvm/beetbox/issues/207