### PR TITLE
Set npm_config_prefix to global location by default.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ nodejs_version: "0.12"
 # nodejs_install_npm_user: username
 
 # The directory for global installations.
-npm_config_prefix: "~/.npm-global"
+npm_config_prefix: "/usr/local/lib/npm"
 
 # Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail.
 npm_config_unsafe_perm: "false"


### PR DESCRIPTION
Note https://github.com/geerlingguy/drupal-vm/pull/715 should be merged first.

Resolves - https://github.com/geerlingguy/ansible-role-nodejs/issues/29