### PR TITLE
add nodesource repo template, kill 0.10 repo case

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,18 +1,13 @@
 ---
-- name: Set up the Nodesource RPM directory for Node.js > 0.10.
+- name: Set up the Nodesource RPM directory for Node.js
   set_fact:
     nodejs_rhel_rpm_dir: "pub_{{ nodejs_version }}"
-  when: nodejs_version != '0.10'
-
-- name: Set up the Nodesource RPM variable for Node.js == 0.10.
-  set_fact:
-    nodejs_rhel_rpm_dir: "pub"
-  when: nodejs_version == '0.10'
 
 - name: Add Nodesource repositories for Node.js.
-  yum:
-    name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
-    state: present
+  template:
+    src: nodesource-el.repo.j2
+    dest: /etc/yum.repos.d/nodesource-el.repo
+    mode: 0644
 
 - name: Ensure Node.js and npm are installed.
   yum: "name=nodejs state=present enablerepo='epel,nodesource'"

--- a/templates/nodesource-el.repo.j2
+++ b/templates/nodesource-el.repo.j2
@@ -1,0 +1,15 @@
+[nodesource]
+name=Node.js Packages for Enterprise Linux {{ ansible_distribution_major_version }} - $basearch
+baseurl=https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL
+
+[nodesource-source]
+name=Node.js for Enterprise Linux {{ ansible_distribution_major_version }} - $basearch - Source
+baseurl=https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/SRPMS
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL
+gpgcheck=1


### PR DESCRIPTION
This allows me to install Node.js 0.12 on RHEL 6. Seems to fix issue #20 / #32 for me. Not sure if you want to wait on upstream since nodesource/distributions#240 is closed?