### PR TITLE
fix create npm global directory bug when user name not eq group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The Node.js version to install. "0.12" is the default and works on all supported
 
 The user for whom the npm packages will be installed can be set here, this defaults to ansible_user
 
+    nodejs_install_npm_group: "{{ nodejs_install_npm_user }}"
+
+The group for whom the npm packages will be installed can be set here, this defaults to nodejs_install_npm_user
+
     npm_config_prefix: "~/.npm-global"
 
 The global installation directory. This should be writeable by the nodejs_install_npm_user.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ nodejs_version: "0.12"
 
 # The user for whom the npm packages will be installed.
 # nodejs_install_npm_user: username
+# nodejs_install_npm_group: groupname
 
 # The directory for global installations.
 npm_config_prefix: "/usr/local/lib/npm"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,16 @@
     nodejs_install_npm_user: "{{ ansible_user }}"
   when: nodejs_install_npm_user is not defined
 
+- name: Define nodejs_install_npm_group
+  set_fact:
+    nodejs_install_npm_group: "{{ nodejs_install_npm_user }}"
+  when: nodejs_install_npm_group is not defined
+
 - name: Create npm global directory
   file:
     path: "{{ npm_config_prefix }}"
     owner: "{{ nodejs_install_npm_user }}"
-    group: "{{ nodejs_install_npm_user }}"
+    group: "{{ nodejs_install_npm_group }}"
     state: directory
 
 - name: Add npm_config_prefix bin directory to global $PATH.

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,7 @@
   vars:
     nodejs_version: "5.x"
     nodejs_install_npm_user: root
+    nodejs_install_npm_group: root
     npm_config_prefix: /root/.npm-global
     npm_config_unsafe_perm: "true"
     nodejs_npm_global_packages:


### PR DESCRIPTION
Hi, when I ansible_user's group name not eq it's user name, this errors happened. I fixed it, please review it. thanks.

```
TASK [geerlingguy.nodejs : Create npm global directory] ************************
fatal: [app]: FAILED! => {"changed": false, "failed": true, "gid": 1000, "group": "ubuntu", "mode": "0755", "msg": "chgrp failed: failed to look up group deploy", "owner": "deploy", "path": "/usr/local/lib/npm", "size": 4096, "state": "directory", "uid": 1001}

```
