### PR TITLE
Fix error with adding nodesource

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,11 +1,10 @@
 ---
-- name: Ensure apt-transport-https is installed.
-  apt: name=apt-transport-https state=present
+- name: Get Nodesource key
+  shell: curl -k -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key > /tmp/nodesource.key
 
 - name: Add Nodesource apt key.
   apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
-    id: "68576280"
+    file: /tmp/nodesource.key
     state: present
 
 - name: Add NodeSource repositories for Node.js.
@@ -15,11 +14,6 @@
   with_items:
     - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
     - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-  register: node_repo
-
-- name: Update apt cache if repo was added.
-  apt: update_cache=yes
-  when: node_repo.changed
 
 - name: Ensure Node.js and npm are installed.
-  apt: "name=nodejs={{ nodejs_version|regex_replace('x', '') }}* state=present"
+  apt: "name=nodejs={{ nodejs_version|regex_replace('x', '') }}* state=present update_cache=yes"


### PR DESCRIPTION
```
fatal: [default]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to validate the SSL certificate for deb.nodesource.com:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine or you can install the `urllib3`, `pyopenssl`, `ndg-httpsclient`, and `pyasn1` python modules to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible"}
```