### PR TITLE
Install package.json if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Add a list of npm packages with a `name` and (optional) `version` to be installe
         version: 0.9.3
       # Install the latest stable release of a package.
       - name: node-sass
+<!-- code block separator -->
+
+    nodejs_package_json_path: "/var/www/application/package.json"
+
+Set a path pointing to a package.json. This will install all of the packages globally.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ nodejs_npm_global_packages: []
 #    version: 0.9.3
 #  # Install the latest stable release of a package.
 #  - name: node-sass
+
+# The path of a package.json
+nodejs_package_json_path: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,3 +48,8 @@
     NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
     NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
   with_items: "{{ nodejs_npm_global_packages }}"
+
+- name: Install package.json
+  npm:
+    path: "{{ package_json_path }}"
+  when: nodejs_package_json_path is defined and nodejs_package_json_path


### PR DESCRIPTION
A lot of nodejs projects have a package.json. Add support to install a package.json if the path is set as a variable.