### PR TITLE
use nodejs_install_npm_group for group permissions if defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   file:
     path: "{{ npm_config_prefix }}"
     owner: "{{ nodejs_install_npm_user }}"
-    group: "{{ nodejs_install_npm_user }}"
+    group: "{{ nodejs_install_npm_group | default(nodejs_install_npm_user) }}"
     state: directory
 
 - name: Add npm_config_prefix bin directory to global $PATH.


### PR DESCRIPTION
Currently, the task "Create npm global directory" creates `npm_config_prefix` with both the user and group permissions as `nodejs_install_npm_user`. Some systems don't have a group with the same name as the user, so I needed this for some hosts.

This adds an optional `nodejs_install_npm_group` variable in vars/main.yml. The group permissions default to `nodejs_install_npm_user` if `nodejs_install_npm_group` isn't defined, so the old behavior is preserved.