### PR TITLE
Support NodeJS versions with more than 1 digit (i.e. 10+) in RHEL

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -34,4 +34,4 @@
   when: ansible_distribution_major_version|int >= 7
 
 - name: Ensure Node.js and npm are installed.
-  yum: "name=nodejs-{{ nodejs_version[0] }}.* state=present enablerepo='epel,nodesource'"
+  yum: "name=nodejs-{{ nodejs_version|regex_replace('x', '') }}* state=present enablerepo='epel,nodesource'"


### PR DESCRIPTION
The previous method did not work for two digit versions (i.e. 10+)

The Debian tasks had a more robust check, it was copied for RHEL

Error Output:
```
    virtualbox-ovf: TASK [nodejs : Ensure Node.js and npm are installed.] **************************
    virtualbox-ovf: fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "No package matching 'nodejs-1.*' found available, installed or updated", "rc": 126, "results": ["No package matching 'nodejs-1.*' found available, installed or updated"]}
```

Related to: https://github.com/geerlingguy/ansible-role-nodejs/issues/79