### PR TITLE
Handle mixed distribution version

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,8 +13,8 @@
     repo: "{{ item }}"
     state: present
   with_items:
-    - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-    - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+    - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_version|regex_replace('(\\w+)\\/*\\w*$', '\\1') }} main"
+    - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_version|regex_replace('(\\w+)\\/*\\w*$', '\\1') }} main"
   register: node_repo
 
 - name: Update apt cache if repo was added.


### PR DESCRIPTION
If any packages from a different release are installed:
* `ansible_distribution_release` will be 'NA'
* `ansible_distribution_version` will be 'release1/release2'

This change uses `ansible_distribution_version` and strips any '/*'
values.