### PR TITLE
Removing epel dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs Node.js on RHEL/CentOS or Debian/Ubuntu.
 
 ## Requirements
 
-Requires the EPEL repository on RedHat/CentOS (you can install it by simply adding the `geerlingguy.repo-epel` role to your playbook).
+None.
 
 ## Role Variables
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -34,4 +34,4 @@
   when: ansible_distribution_major_version|int >= 7
 
 - name: Ensure Node.js and npm are installed.
-  yum: "name=nodejs-{{ nodejs_version|regex_replace('x', '') }}* state=present enablerepo='epel,nodesource'"
+  yum: "name=nodejs-{{ nodejs_version|regex_replace('x', '') }}* state=present enablerepo='nodesource'"


### PR DESCRIPTION
`EPEL` repository isn't needed anymore because it's adding nodesource

Additionally, enablerepo='epel,nodesource' will fail if `EPEL` isn't present, however packages might as well get installed from the `nodesource` repository, so no need to put a dependency on EPEL.