### PR TITLE
Updated Nodesource key, dirmngr, minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    nodejs_version: "8.x"
+    nodejs_version: "10.x"
 
-The Node.js version to install. "8.x" is the default and works on most supported OSes. Other versions such as "0.12", "4.x", "5.x", "6.x", "8.x", "10.x" etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
+The Node.js version to install. "10.x" is the default and works on most supported OSes. Other versions such as "0.12", "4.x", "5.x", "6.x", "8.x", "10.x" etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
 
     nodejs_install_npm_user: "{{ ansible_ssh_user }}"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,10 +2,16 @@
 - name: Ensure apt-transport-https is installed.
   apt: name=apt-transport-https state=present
 
+# Install dirmngr (required by apt-key).
+- name: Install certificate management service.
+  apt:
+    name: dirmngr
+    state: present
+
 - name: Add Nodesource apt key.
   apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
-    id: "68576280"
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    id: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
     state: present
 
 - name: Add NodeSource repositories for Node.js.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -11,7 +11,7 @@
 
 - name: Import Nodesource RPM key (CentOS < 7).
   rpm_key:
-    key: http://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
+    key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
   when: ansible_distribution_major_version|int < 7
 
@@ -23,7 +23,7 @@
 
 - name: Add Nodesource repositories for Node.js (CentOS < 7).
   yum:
-    name: "http://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version|int < 7
 


### PR DESCRIPTION
- Updated Nodesource key
- Added a task to make sure that [dirmngr](https://packages.debian.org/stretch/dirmngr) is installed (because is used by apt-key at run-time)
- Fixed RedHat tasks by switching to https where http was used
- Fixed default Node.js version in README
