### PR TITLE
remove yum cache before install nodejs

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -27,6 +27,14 @@
     state: present
   when: ansible_distribution_major_version|int < 7
 
+- name: clean yum cache.
+  shell: |
+    /bin/rm -rf /var/cache/yum
+    /usr/bin/yum remove -y nodejs
+    /bin/rm /etc/yum.repos.d/nodesource*
+    /usr/bin/yum clean all
+    /usr/bin/curl -sL https://rpm.nodesource.com/setup_10.x | bash -
+
 - name: Add Nodesource repositories for Node.js (CentOS 7+).
   yum:
     name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"


### PR DESCRIPTION
Without this modification Nodejs will remain on version 5.12.0 on CentOS 7.4