### PR TITLE
Remove APT update_cache task since it's handled by apt_repository

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,11 +15,6 @@
   with_items:
     - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
     - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-  register: node_repo
-
-- name: Update apt cache if repo was added.
-  apt: update_cache=yes
-  when: node_repo.changed
 
 - name: Ensure Node.js and npm are installed.
   apt: "name=nodejs={{ nodejs_version|regex_replace('x', '') }}* state=present"


### PR DESCRIPTION
From https://docs.ansible.com/ansible/latest/modules/apt_repository_module.html: update_cache is set to true by default.

"Run the equivalent of apt-get update when a change occurs. Cache updates are run after making changes."