### PR TITLE
Apparently the package name is now "nodejs" for yum

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -34,4 +34,4 @@
   when: ansible_distribution_major_version|int >= 7
 
 - name: Ensure Node.js and npm are installed.
-  yum: "name=nodejs-{{ nodejs_version|regex_replace('x', '') }}* state=present enablerepo='nodesource'"
+  yum: "name=nodejs state=present enablerepo='nodesource'"


### PR DESCRIPTION
```
TASK [geerlingguy.nodejs : Ensure Node.js and npm are installed.] *********************************************************************************************************************************************************************************************************************************************************fatal: [odin]: FAILED! => {"changed": false, "failures": ["No package nodejs-10.* available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
        to retry, use: --limit @/home/halkeye/go/src/github.com/halkeye/halkeye-ansible/main.retry
```

Looking at the NODEPKG variable of the setup urls, it seems like the version number is no longer in the package name:
* https://rpm.nodesource.com/setup_7.x
* https://rpm.nodesource.com/setup_8.x
* https://rpm.nodesource.com/setup_9.x
* https://rpm.nodesource.com/setup_10.x
* https://rpm.nodesource.com/setup_11.x

I made the change locally and things work now.