### PR TITLE
[security] fix $PATH modification for .profile.d in npm.sh

### DIFF
--- a/templates/npm.sh.j2
+++ b/templates/npm.sh.j2
@@ -1,3 +1,3 @@
-export PATH={{ npm_config_prefix }}/bin:$PATH
+export PATH=$PATH:{{ npm_config_prefix }}/bin
 export NPM_CONFIG_PREFIX={{ npm_config_prefix }}
 export NODE_PATH=$NODE_PATH:{{ npm_config_prefix }}/lib/node_modules


### PR DESCRIPTION
Change the PATH variable modification in profile.d directory.

As shell, like bash, will search in the order provided in $PATH.

Nodejs install should not modify this order. And **{{ npm_config_prefix }}/bin** should not be before **/bin** and **/usr/bin**

For exemple, if a npm package install a binary named **ls**, it can replace the system one, so it can be big security problem.

https://www.tldp.org/HOWTO/Path-12.html



