### PR TITLE
add nodejs_install_npm_group role variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The Node.js version to install. "12.x" is the default and works on most supporte
 
 The user for whom the npm packages will be installed can be set here, this defaults to `ansible_user`.
 
+    nodejs_install_npm_group: "{{ nodejs_install_npm_user }}"
+
+The group that the above mentioned user is in.  Defaults to the value that nodejs_install_npm_user is set to.
+
     npm_config_prefix: "/usr/local/lib/npm"
 
 The global installation directory. This should be writeable by the `nodejs_install_npm_user`.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,16 @@
     nodejs_install_npm_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
   when: nodejs_install_npm_user is not defined
 
+- name: Define nodejs_install_npm_group
+  set_fact:
+    nodejs_install_npm_group: "{{ nodejs_install_npm_user }}"
+  when: nodejs_install_npm_group is not defined
+
 - name: Create npm global directory
   file:
     path: "{{ npm_config_prefix }}"
     owner: "{{ nodejs_install_npm_user }}"
-    group: "{{ nodejs_install_npm_user }}"
+    group: "{{ nodejs_install_npm_group }}"
     state: directory
 
 - name: Add npm_config_prefix bin directory to global $PATH.


### PR DESCRIPTION
I ran into a situation where the group differed from the user when running the 'Create npm global directory' task.  I have created an additional role variable, nodejs_install_npm_group, which defaults to the value of nodejs_install_npm_user for backwards compatibility.