### PR TITLE
update yum cache upon adding nodesource repo

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -20,12 +20,19 @@
     name: "http://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version|int < 7
+  register: node_repo
 
 - name: Add Nodesource repositories for Node.js (CentOS 7+).
   yum:
     name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version|int >= 7
+  register: node_repo
+
+- name: Update package cache if repo was added.
+  yum: update_cache=yes
+  when: node_repo.changed
+  tags: ['skip_ansible_lint']
 
 - name: Ensure Node.js AppStream module is disabled (CentOS 8+).
   command: yum module disable -y nodejs


### PR DESCRIPTION
to upgrade to a newer version of nodejs (12 to 13 in this case) i use the following playbook. with pre tasks, i check if a version change will happen and uninstall old nodejs and repo package before your role runs. during that process i came across the problem that, when your role adds the repo again, a cache upgrade is needed so that `yum: name=nodejs-13.* state=present` finds the package.

so i basically just replicated what happens in `setup-Debian.yml`, updating the package cache if the repo step changed.

```yml
---
- hosts: all
  become: true
  vars:
    nodejs_version: 13.x
    nodejs_install_npm_user: root
  roles:
    - role: geerlingguy.nodejs
  pre_tasks:
    - name: check if current nodejs repo is set up
      command: grep -Fq "https://rpm.nodesource.com/pub_{{nodejs_version}}" /etc/yum.repos.d/nodesource-el7.repo
      register: nodesource_repo_grep
      check_mode: no
      ignore_errors: yes
      changed_when: no

    - name: remove unfit nodejs repo
      yum: name={{ item }} state=absent
      when: nodesource_repo_grep.rc != 0
      with_items:
        - nodejs
        - nodesource-release
```