### PR TITLE
[security] Add security to limit the path change to the nodejs user

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The global installation directory. This should be writeable by the `nodejs_insta
 
 Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail.
 
+    apply_path_change_for_node_user_only: "false"
+
+Set to `True` to limit path change to the nodejs user it avoid root (if it's not the nodejs user) to have access to npm binaries.
+
     nodejs_npm_global_packages: []
 
 A list of npm packages with a `name` and (optional) `version` to be installed globally. For example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,7 @@ nodejs_npm_global_packages: []
 
 # The path of a package.json file used to install packages globally.
 nodejs_package_json_path: ""
+
+# Deploy a specific template for /etc/profile.d/npm.sh who
+# apply path modification for node js user only
+apply_path_change_for_node_user_only: false

--- a/templates/npm.sh.j2
+++ b/templates/npm.sh.j2
@@ -1,3 +1,9 @@
-export PATH=$PATH:{{ npm_config_prefix }}/bin
-export NPM_CONFIG_PREFIX={{ npm_config_prefix }}
-export NODE_PATH=$NODE_PATH:{{ npm_config_prefix }}/lib/node_modules
+{% if apply_path_change_for_node_user_only is defined and apply_path_change_for_node_user_only is sameas true %}
+if [ "$USER" == "{{ nodejs_install_npm_user }}" ]; then
+{% endif %}
+  export PATH=$PATH:{{ npm_config_prefix }}/bin
+  export NPM_CONFIG_PREFIX={{ npm_config_prefix }}
+  export NODE_PATH=$NODE_PATH:{{ npm_config_prefix }}/lib/node_modules
+{% if apply_path_change_for_node_user_only is defined and apply_path_change_for_node_user_only is sameas true %}
+fi
+{% endif %}


### PR DESCRIPTION
The answer to [the issue #125](https://github.com/geerlingguy/ansible-role-nodejs/issues/125).
To not change the actual way it work I created a new var and add a condition in the template.

The [PR #102](https://github.com/geerlingguy/ansible-role-nodejs/pull/102) only block overriding existing binary but it still allow the creation of new binaries who can be executed by root.