### PR TITLE
Default to latest LTS version 14.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    nodejs_version: "12.x"
+    nodejs_version: "14.x"
 
-The Node.js version to install. "12.x" is the default and works on most supported OSes. Other versions such as "8.x", "10.x", "13.x", etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
+The Node.js version to install. "14.x" is the default and works on most supported OSes. Other versions such as "8.x", "10.x", "13.x", etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
 
     nodejs_install_npm_user: "{{ ansible_ssh_user }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Set the version of Node.js to install (8.x", "10.x", "12.x", "13.x", etc.).
+# Set the version of Node.js to install ("12.x", "13.x", "14.x", "15.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
 nodejs_version: "14.x"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Set the version of Node.js to install (8.x", "10.x", "12.x", "13.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
-nodejs_version: "12.x"
+nodejs_version: "14.x"
 
 # The user for whom the npm packages will be installed.
 # nodejs_install_npm_user: username


### PR DESCRIPTION
14.x has been out for almost a year now and has been the Active LTS since October 2020. I think it is probably safe to make this default now.