### PR TITLE
IPv6: Nodesource apt key from their website

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,8 +8,8 @@
 
 - name: Add Nodesource apt key.
   apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
-    id: "68576280"
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    id: 1655A0AB68576280
     state: present
 
 - name: Add NodeSource repositories for Node.js.


### PR DESCRIPTION
The keyserver.ubuntu.com do not support the current version of the
Internet Protocol, as one can query [0] or look up in their issue
tracker [1]. Thus, this role cannot be executed on IPv6-only hosts.

However, Nodesource supports both IPv6 and has their public key
available on their website.

[0] dig AAAA keyserver.ubuntu.com
[1] https://answers.launchpad.net/launchpad/+question/189094