### PR TITLE
Remove a deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     src: npm.sh.j2
     dest: /etc/profile.d/npm.sh
     mode: 0644
-  when: nodejs_generate_etc_profile
+  when: nodejs_generate_etc_profile | bool
 
 - name: Ensure npm global packages are installed.
   npm:


### PR DESCRIPTION
When running the role, Ansible prints a deprecation warning message.
Here is a quick fix to force this conditional bare variable as a boolean.