### PR TITLE
Allow to specify exact nodejs version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The Node.js version to install. "14.x" is the default and works on most supported OSes. Other versions such as "8.x", "10.x", "13.x", etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
 
+    nodejs_exact_version: "16.15.0-*"
+
+Optional, exact Node.js version to install. The `nodejs_version` is required and should be configured with this option. Without `nodejs_exact_version` role installs last available Node.js version.
+
     nodejs_install_npm_user: "{{ ansible_ssh_user }}"
 
 The user for whom the npm packages will be installed can be set here, this defaults to `ansible_user`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
 nodejs_version: "14.x"
 
+# Specify exact Node.js version to install.
+When empty, role always installs latest version from repository.
+nodejs_exact_version: ""
+
 # The user for whom the npm packages will be installed.
 # nodejs_install_npm_user: username
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 nodejs_version: "14.x"
 
 # Specify exact Node.js version to install.
-When empty, role always installs latest version from repository.
+# When empty, role always installs latest version from repository.
 nodejs_exact_version: ""
 
 # The user for whom the npm packages will be installed.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -30,10 +30,10 @@
   apt:
     name: "nodejs={{ nodejs_version|regex_replace('x', '') }}*"
     state: present
-  when: nodejs_exact_version is not defined
+  when: nodejs_exact_version == ""
 
 - name: Ensure specified version of Node.js and npm are installed.
   apt:
     name: "nodejs={{ nodejs_exact_version }}"
     state: present
-  when: nodejs_exact_version is defined
+  when: nodejs_exact_version != ""

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -30,3 +30,10 @@
   apt:
     name: "nodejs={{ nodejs_version|regex_replace('x', '') }}*"
     state: present
+  when: nodejs_exact_version is not defined
+
+- name: Ensure specified version of Node.js and npm are installed.
+  apt:
+    name: "nodejs={{ nodejs_exact_version }}"
+    state: present
+  when: nodejs_exact_version is defined


### PR DESCRIPTION
By default, ansible-role-nodejs always installs latest nodejs version. Actually, it upgrades it to the latest version on every run which may cause some problems in production environment.

This PR adds the option to choose the exact nodejs version to install. It doesn't change default behavior of the role.