### PR TITLE
Bump default nodejs version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Set the version of Node.js to install ("12.x", "13.x", "14.x", "15.x", etc.).
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
-nodejs_version: "14.x"
+nodejs_version: "16.x"
 
 # The user for whom the npm packages will be installed.
 # nodejs_install_npm_user: username


### PR DESCRIPTION
According to the NodeJS website (https://nodejs.org/en/), version 16 is "Recommended for most users".  According to nodesource (https://github.com/nodesource/distributions), this version is available in the nodesource repos.