### PR TITLE
WIP: tasks.setup-Debian: configurable repo url, small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ nodejs_version: "16.x"
 The Node.js version to install. "14.x" is the default and works on most supported OSes. Other versions such as "10.x", "14.x", "18.x", etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
 
 ```yaml
+nodejs_repourl: "https://deb.nodesource.com"
+```
+
+The Node.js repository to use for installation.
+
+```yaml
 nodejs_install_npm_user: "{{ ansible_ssh_user }}"
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 # Version numbers from Nodesource: https://github.com/nodesource/distributions
 nodejs_version: "16.x"
 
+# The Node.js repository to use for installation.
+nodejs_repourl: "https://deb.nodesource.com"
+
 # The user for whom the npm packages will be installed.
 # nodejs_install_npm_user: username
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
-- import_tasks: setup-RedHat.yml
+- ansible.builtin.import_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- import_tasks: setup-Debian.yml
+- ansible.builtin.import_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Define nodejs_install_npm_user
-  set_fact:
+  ansible.builtin.set_fact:
     nodejs_install_npm_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
   when: nodejs_install_npm_user is not defined
 
 - name: Create npm global directory
-  file:
+  ansible.builtin.file:
     path: "{{ npm_config_prefix }}"
     owner: "{{ nodejs_install_npm_user }}"
     group: "{{ nodejs_install_npm_user }}"
@@ -19,14 +19,14 @@
     mode: 0755
 
 - name: Add npm_config_prefix bin directory to global $PATH.
-  template:
+  ansible.builtin.template:
     src: npm.sh.j2
     dest: /etc/profile.d/npm.sh
     mode: 0644
   when: nodejs_generate_etc_profile
 
 - name: Ensure npm global packages are installed.
-  npm:
+  ansible.builtin.npm:
     name: "{{ item.name | default(item) }}"
     version: "{{ item.version | default(omit) }}"
     global: true
@@ -38,6 +38,6 @@
   with_items: "{{ nodejs_npm_global_packages }}"
 
 - name: Install packages defined in a given package.json.
-  npm:
+  ansible.builtin.npm:
     path: "{{ nodejs_package_json_path }}"
   when: nodejs_package_json_path is defined and nodejs_package_json_path

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -19,8 +19,8 @@
     filename: "node_{{ nodejs_version }}"
     update_cache: no
   with_items:
-    - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-    - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+    - "deb {{ nodejs_repourl }}/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+    - "deb-src {{ nodejs_repourl }}/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
   register: node_repo
 
 - name: Update apt cache if repo was added.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,6 +16,7 @@
   ansible.builtin.apt_repository:
     repo: "{{ item }}"
     state: present
+    update_cache: no
   with_items:
     - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
     - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,19 +1,19 @@
 ---
 - name: Ensure dependencies are present.
-  apt:
+  ansible.builtin.apt:
     name:
       - apt-transport-https
       - gnupg2
     state: present
 
 - name: Add Nodesource apt key.
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     id: "68576280"
     state: present
 
 - name: Add NodeSource repositories for Node.js.
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "{{ item }}"
     state: present
   with_items:
@@ -22,11 +22,11 @@
   register: node_repo
 
 - name: Update apt cache if repo was added.
-  apt: update_cache=yes
+  ansible.builtin.apt: update_cache=yes
   when: node_repo is changed
   tags: ['skip_ansible_lint']
 
 - name: Ensure Node.js and npm are installed.
-  apt:
+  ansible.builtin.apt:
     name: "nodejs={{ nodejs_version | regex_replace('x', '') }}*"
     state: present

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,6 +16,7 @@
   ansible.builtin.apt_repository:
     repo: "{{ item }}"
     state: present
+    filename: "node_{{ nodejs_version }}"
     update_cache: no
   with_items:
     - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,41 +1,41 @@
 ---
 - name: Set up the Nodesource RPM directory.
-  set_fact:
+  ansible.builtin.set_fact:
     nodejs_rhel_rpm_dir: "pub_{{ nodejs_version }}"
 
 - name: Import Nodesource RPM key (CentOS < 7).
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: http://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
   when: ansible_distribution_major_version | int < 7
 
 - name: Import Nodesource RPM key (CentOS 7+).
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
   when: ansible_distribution_major_version | int >= 7
 
 - name: Add Nodesource repositories for Node.js (CentOS < 7).
-  yum:
+  ansible.builtin.yum:
     name: "http://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version | int < 7
   register: node_repo
 
 - name: Add Nodesource repositories for Node.js (CentOS 7+).
-  yum:
+  ansible.builtin.yum:
     name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version | int >= 7
   register: node_repo
 
 - name: Update package cache if repo was added.
-  yum: update_cache=yes
+  ansible.builtin.yum: update_cache=yes
   when: node_repo is changed
   tags: ['skip_ansible_lint']
 
 - name: Ensure Node.js AppStream module is disabled (CentOS 8+).
-  command: yum module disable -y nodejs
+  ansible.builtin.command: yum module disable -y nodejs
   args:
     warn: false
   register: module_disable
@@ -43,7 +43,7 @@
   when: ansible_distribution_major_version | int >= 8
 
 - name: Ensure Node.js and npm are installed.
-  yum:
+  ansible.builtin.yum:
     name: "nodejs-{{ nodejs_version | regex_replace('x', '') }}*"
     state: present
     enablerepo: nodesource


### PR DESCRIPTION
This PR adds support for a configurable repository URL for Debian distributions.
In my use case this was necessary to properly configure the sources for a local `apt-cacher-ng` instance which does not play well with https requests.

While I was at it, I also contributed a couple *very* small improvements:
- updated all tasks to use FQCNs
- avoid updating packages cache for each repo line added by `apt_repository`, since the module does by default ([docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_repository_module.html#parameter-update_cache))
- defined a name for the apt source.list file, to avoid long unpleasant autogenerated filenames

Looking forward your thoughts on this