### PR TITLE
Avoid using the deprecated apt-key module for new ubuntu versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 */__pycache__
 *.pyc
 .cache
-
+.idea/

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,6 +11,7 @@
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     id: "68576280"
     state: present
+  when: ansible_distribution_major_version | int < 22
 
 - name: Add NodeSource repositories for Node.js.
   apt_repository:
@@ -20,6 +21,31 @@
     - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
     - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
   register: node_repo
+  when: ansible_distribution_major_version | int < 22
+
+- name: Remove legacy apt key
+  apt_key:
+    id: "68576280"
+    state: absent
+  when: ansible_distribution_major_version | int >= 22
+
+- name: Add Nodesource apt key
+  get_url:
+    url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+    dest: /etc/apt/trusted.gpg.d/nodesource.asc
+    checksum: sha1:015b8603bfa93149bba61bee4f5130e9f3f2c0f5
+    mode: 0644
+  when: ansible_distribution_major_version | int >= 22
+
+- name: Add NodeSource repositories for Node.js.
+  apt_repository:
+    repo: "{{ item }}"
+    state: present
+  with_items:
+    - "deb [signed-by=/etc/apt/trusted.gpg.d/nodesource.asc] https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+    - "deb-src [signed-by=/etc/apt/trusted.gpg.d/nodesource.asc] https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+  register: node_repo
+  when: ansible_distribution_major_version | int >= 22
 
 - name: Update apt cache if repo was added.
   apt: update_cache=yes


### PR DESCRIPTION
As the https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html describes:

> The apt-key command has been deprecated and suggests to ‘manage keyring files in trusted.gpg.d instead’. See the Debian wiki for details. This module is kept for backwards compatibility for systems that still use apt-key as the main way to manage apt repository keys.

---

Although the best alternative for the apt-key would be to

```
gpg --dearmor
```

the key, I still hope this version without `gpg --dearmor` is also good enough and also described hee https://opensource.com/article/22/9/deprecated-linux-apt-key as a valid alternative (even though  not the best)