### PR TITLE
Implement separate group variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ nodejs_install_npm_user: "{{ ansible_ssh_user }}"
 The user for whom the npm packages will be installed can be set here, this defaults to `ansible_user`.
 
 ```yaml
+nodejs_install_npm_group: "{{ nodejs_install_npm_user }}"
+```
+
+The group that the above mentioned user is in.  Defaults to the value that `nodejs_install_npm_user` is set to.
+
+```yaml
 npm_config_prefix: "/usr/local/lib/npm"
 ```
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   file:
     path: "{{ npm_config_prefix }}"
     owner: "{{ nodejs_install_npm_user }}"
-    group: "{{ nodejs_install_npm_group  }}"
+    group: "{{ nodejs_install_npm_group }}"
     state: directory
     mode: 0755
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,16 @@
     nodejs_install_npm_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
   when: nodejs_install_npm_user is not defined
 
+- name: Define nodejs_install_npm_group
+  set_fact:
+    nodejs_install_npm_group: "{{ nodejs_install_npm_user }}"
+  when: nodejs_install_npm_group is not defined
+
 - name: Create npm global directory
   file:
     path: "{{ npm_config_prefix }}"
     owner: "{{ nodejs_install_npm_user }}"
-    group: "{{ nodejs_install_npm_user }}"
+    group: "{{ nodejs_install_npm_group  }}"
     state: directory
     mode: 0755
 


### PR DESCRIPTION
This reopens #91 and rerolls @olandere's changes against the latest master. By the looks of it, this feature is still useful for others, and it's essential to us because in the context we're installing Node.js, it's impossible (or at least inadvisable) to use the workaround to create a group with the same name as the user.