### PR TITLE
fix "No package matching 'gnupg2' is available"

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,6 +5,7 @@
       - apt-transport-https
       - gnupg2
     state: present
+    update_cache: yes
 
 - name: Add Nodesource apt key.
   apt_key:


### PR DESCRIPTION
On a freshly installed Ubuntu, I get this `No package matching 'gnupg2' is available` after I did `apt-get update` the role installed the package.