### PR TITLE
fix: apt key deprecation issue

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,19 +6,18 @@
       - gnupg2
     state: present
 
-- name: Add Nodesource apt key.
-  apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
-    id: "68576280"
-    state: present
 
 - name: Add NodeSource repositories for Node.js.
-  apt_repository:
-    repo: "{{ item }}"
+  deb822_repository:
+    name: nodesource_{{ nodejs_version }}
+    uris: "https://deb.nodesource.com/node_{{ nodejs_version }}"
+    types:
+      - deb
+      - deb-src
+    suites: "{{ ansible_distribution_release }}"
+    components: main
+    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     state: present
-  with_items:
-    - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-    - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
   register: node_repo
 
 - name: Update apt cache if repo was added.


### PR DESCRIPTION
Fix https://github.com/geerlingguy/ansible-role-nodejs/issues/151

- Switched to using deb822 and deb822_repository module
- deb822_repository With `signed-by` which handle keyring correctly