### PR TITLE
NodeSource Repository Update

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,31 +1,39 @@
 ---
 - name: Ensure dependencies are present.
-  apt:
+  ansible.builtin.apt:
     name:
       - apt-transport-https
       - gnupg2
     state: present
 
+- name: Download NodeSource's signing key.
+  # NodeSource's web server discriminates the User-Agent used by the deb822_repository module.
+  # https://github.com/nodesource/distributions/issues/1723
+  ansible.builtin.get_url:
+    url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+    dest: /etc/apt/signing-key-nodesource-repo.asc
+    owner: root
+    group: root
+    mode: '0444'
+  register: node_signing_key
 
 - name: Add NodeSource repositories for Node.js.
-  deb822_repository:
+  ansible.builtin.deb822_repository:
     name: nodesource_{{ nodejs_version }}
     uris: "https://deb.nodesource.com/node_{{ nodejs_version }}"
-    types:
-      - deb
-      - deb-src
-    suites: "{{ ansible_distribution_release }}"
+    types: deb
+    suites: nodistro
     components: main
-    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
+    signed_by: "{{ node_signing_key.dest }}"
     state: present
   register: node_repo
 
 - name: Update apt cache if repo was added.
-  apt: update_cache=yes
+  ansible.builtin.apt: update_cache=yes
   when: node_repo is changed
   tags: ['skip_ansible_lint']
 
 - name: Ensure Node.js and npm are installed.
-  apt:
+  ansible.builtin.apt:
     name: "nodejs={{ nodejs_version | regex_replace('x', '') }}*"
     state: present

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,19 +6,18 @@
       - gnupg2
     state: present
 
-- name: Add Nodesource apt key.
-  apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
-    id: "68576280"
-    state: present
 
 - name: Add NodeSource repositories for Node.js.
-  apt_repository:
-    repo: "{{ item }}"
+  deb822_repository:
+    name: nodesource_{{ nodejs_version }}
+    uris: "https://deb.nodesource.com/node_{{ nodejs_version }}"
+    types:
+      - deb
+      - deb-src
+    suites: "{{ ansible_distribution_release }}"
+    components: main
+    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     state: present
-  with_items:
-    - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-    - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
   register: node_repo
 
 - name: Update apt cache if repo was added.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -17,14 +17,14 @@
 
 - name: Add Nodesource repositories for Node.js (CentOS < 7).
   yum:
-    name: "http://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    name: "http://rpm.nodesource.com/pub_{{ nodejs_rhel_rpm_dir }}/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version | int < 7
   register: node_repo
 
 - name: Add Nodesource repositories for Node.js (CentOS 7+).
   yum:
-    name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    name: "https://rpm.nodesource.com/pub_{{ nodejs_rhel_rpm_dir }}/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm"
     state: present
   when: ansible_distribution_major_version | int >= 7
   register: node_repo


### PR DESCRIPTION
The old NodeSource repository is no longer updated. The new ["nodistro" suite](https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository) should now be used instead to receive future updates. This was already addressed in both #153 and #154 and merging this would close this two issues.

This Pull Request builds on top of #152 and contains two commits, one from @MohamedLamineAllal to switch from the old `apt_key` to `deb822_repository` and one from me to switch to the new repository. As this PR wraps @MohamedLamineAllal's changes, merging this would allow closing the other one.

Please note: I have tested the Debian setup successfully with Node.js version "18.x" and "20.x". The RedHat setup, however, was not tested as I do not have any RedHat-based systems laying around.