### PR TITLE
Provide a flag to allow disabling of GPG checking

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,6 @@ nodejs_package_json_path: ""
 # Whether or not /etc/profile.d/npm.sh (globa) must be generated.
 # Set to false if you need to handle this manually with a per-user install.
 nodejs_generate_etc_profile: "true"
+
+# Whether or not to verify the GPG key while installing the package
+nodejs_disable_gpg_check: "false

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -28,3 +28,4 @@
     name: "nodejs-{{ nodejs_version | regex_replace('x', '') }}*"
     state: present
     enablerepo: nodesource
+    disable_gpg_check: "{{ nodejs_disable_gpg_check | default(omit) }}"


### PR DESCRIPTION
In some situations, the GPG key of the package might be untrusted. This new `nodejs_disable_gpg_check` flag allows for users to skip the GPG check at their own peril.