### PR TITLE
Add architecture support for NodeSource repository and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.pyc
 .cache
 
+.idea
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -65,8 +65,15 @@ Set a path pointing to a particular `package.json` (e.g. `"/var/www/app/package.
 ```yaml
 nodejs_generate_etc_profile: "true"
 ```
-    
+
 By default the role will create `/etc/profile.d/npm.sh` with exported variables (`PATH`, `NPM_CONFIG_PREFIX`, `NODE_PATH`). If you prefer to avoid generating that file (e.g. you want to set the variables yourself for a non-global install), set it to "false".
+
+```yaml
+nodejs_architecture: ""
+```
+
+The architecture for the NodeSource repository (e.g., "amd64", "i386", "arm64", etc.). By default, this is empty, which means the role will automatically detect the architecture based on `ansible_architecture`. You only need to set this if you want to override the auto-detection.
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,7 @@ nodejs_package_json_path: ""
 # Whether or not /etc/profile.d/npm.sh (globa) must be generated.
 # Set to false if you need to handle this manually with a per-user install.
 nodejs_generate_etc_profile: "true"
+
+# Architecture for the NodeSource repository (amd64, i386, etc.)
+# Leave empty to auto-detect architecture from ansible_architecture
+nodejs_architecture: ""

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,8 +15,23 @@
     dest: /etc/apt/signing-key-nodesource-repo.asc
     owner: root
     group: root
-    mode: '0444'
+    mode: "0444"
   register: node_signing_key
+
+- name: Set architecture for NodeSource repository
+  ansible.builtin.set_fact:
+    nodejs_repo_arch: "{{ nodejs_architecture | default('') }}"
+  when: nodejs_architecture is defined and nodejs_architecture != ""
+
+- name: Set architecture for NodeSource repository based on ansible_architecture
+  ansible.builtin.set_fact:
+    nodejs_repo_arch: >-
+      {% if ansible_architecture == 'x86_64' %}amd64
+      {% elif ansible_architecture == 'i386' %}i386
+      {% elif ansible_architecture == 'aarch64' %}arm64
+      {% elif ansible_architecture == 'armv7l' %}armhf
+      {% else %}{{ ansible_architecture }}{% endif %}
+  when: nodejs_architecture is not defined or nodejs_architecture == ""
 
 - name: Add NodeSource repositories for Node.js.
   ansible.builtin.deb822_repository:
@@ -26,13 +41,14 @@
     suites: nodistro
     components: main
     signed_by: "{{ node_signing_key.dest }}"
+    architectures: "{{ nodejs_repo_arch }}"
     state: present
   register: node_repo
 
 - name: Update apt cache if repo was added.
   ansible.builtin.apt: update_cache=yes
   when: node_repo is changed
-  tags: ['skip_ansible_lint']
+  tags: ["skip_ansible_lint"]
 
 - name: Ensure Node.js and npm are installed.
   ansible.builtin.apt:


### PR DESCRIPTION
Hey Jeff, I had some problems with this repo on Ubuntu 24 Noble. It couldn't determine the architecture and it was trying to download Node from i386, which doesn't exist on the Nodesource side of things. So I added some stuff to fix that and detect the correct architecture. It's working now for me on my home lab.

- Updated .gitignore to exclude IDE and OS-specific files.
- Enhanced README.md with new nodejs_architecture variable for specifying NodeSource repository architecture.
- Modified defaults/main.yml to include nodejs_architecture with a description.
- Updated setup-Debian.yml to set architecture for NodeSource repository based on user input or auto-detection from ansible_architecture.