### PR TITLE
Make nodejs_generate_etc_profile an actual bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ nodejs_package_json_path: ""
 Set a path pointing to a particular `package.json` (e.g. `"/var/www/app/package.json"`). This will install all of the defined packages globally using Ansible's `npm` module.
 
 ```yaml
-nodejs_generate_etc_profile: "true"
+nodejs_generate_etc_profile: true
 ```
     
 By default the role will create `/etc/profile.d/npm.sh` with exported variables (`PATH`, `NPM_CONFIG_PREFIX`, `NODE_PATH`). If you prefer to avoid generating that file (e.g. you want to set the variables yourself for a non-global install), set it to "false".

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,4 +28,4 @@ nodejs_package_json_path: ""
 
 # Whether or not /etc/profile.d/npm.sh (globa) must be generated.
 # Set to false if you need to handle this manually with a per-user install.
-nodejs_generate_etc_profile: "true"
+nodejs_generate_etc_profile: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ npm_config_prefix: "/usr/local/lib/npm"
 
 # Set to true to suppress the UID/GID switching when running package scripts. If
 # set explicitly to false, then installing as a non-root user will fail.
-npm_config_unsafe_perm: "false"
+npm_config_unsafe_perm: false
 
 # Define a list of global packages to be installed with NPM.
 nodejs_npm_global_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,4 +40,4 @@
 - name: Install packages defined in a given package.json.
   npm:
     path: "{{ nodejs_package_json_path }}"
-  when: nodejs_package_json_path is defined and nodejs_package_json_path
+  when: nodejs_package_json_path is defined and nodejs_package_json_path | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,10 +34,10 @@
   environment:
     NPM_CONFIG_PREFIX: "{{ npm_config_prefix }}"
     NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
-    NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm | bool }}"
+    NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
   with_items: "{{ nodejs_npm_global_packages }}"
 
 - name: Install packages defined in a given package.json.
   npm:
     path: "{{ nodejs_package_json_path }}"
-  when: nodejs_package_json_path is defined and nodejs_package_json_path | bool
+  when: nodejs_package_json_path is defined and (nodejs_package_json_path | bool)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
   environment:
     NPM_CONFIG_PREFIX: "{{ npm_config_prefix }}"
     NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
-    NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
+    NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm | bool }}"
   with_items: "{{ nodejs_npm_global_packages }}"
 
 - name: Install packages defined in a given package.json.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,4 +40,4 @@
 - name: Install packages defined in a given package.json.
   npm:
     path: "{{ nodejs_package_json_path }}"
-  when: nodejs_package_json_path is defined and (nodejs_package_json_path | bool)
+  when: nodejs_package_json_path is defined and nodejs_package_json_path != ""


### PR DESCRIPTION
Ansible 2.19 requires values used in conditionals to be actual bools and not just values that can be coerced to a bool