### PR TITLE
fix: make `nodejs_generate_etc_profile` a real boolean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,14 @@ jobs:
           #   playbook: converge.yml
           - distro: ubuntu2204
             playbook: converge.yml
+          - distro: debian13
+            playbook: converge.yml
           - distro: debian12
             playbook: converge.yml
           - distro: debian11
             playbook: converge.yml
 
-          - distro: debian12
+          - distro: debian13
             playbook: playbook-latest.yml
 
     steps:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ nodejs_package_json_path: ""
 Set a path pointing to a particular `package.json` (e.g. `"/var/www/app/package.json"`). This will install all of the defined packages globally using Ansible's `npm` module.
 
 ```yaml
-nodejs_generate_etc_profile: "true"
+nodejs_generate_etc_profile: true
 ```
     
 By default the role will create `/etc/profile.d/npm.sh` with exported variables (`PATH`, `NPM_CONFIG_PREFIX`, `NODE_PATH`). If you prefer to avoid generating that file (e.g. you want to set the variables yourself for a non-global install), set it to "false".

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,4 +28,4 @@ nodejs_package_json_path: ""
 
 # Whether or not /etc/profile.d/npm.sh (globa) must be generated.
 # Set to false if you need to handle this manually with a per-user install.
-nodejs_generate_etc_profile: "true"
+nodejs_generate_etc_profile: true


### PR DESCRIPTION
Fixes "Task failed: Conditional result (True) was derived from value of type 'str'" with latest Ansible versions.