### PR TITLE
change debian url repositories

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -21,7 +21,7 @@
 - name: Add NodeSource repositories for Node.js.
   ansible.builtin.deb822_repository:
     name: nodesource_{{ nodejs_version }}
-    uris: "https://deb.nodesource.com/node_{{ nodejs_version }}"
+    uris: "https://deb.nodesource.com/setup_{{ nodejs_version }}"
     types: deb
     suites: nodistro
     components: main


### PR DESCRIPTION
Fix for this issue: https://github.com/geerlingguy/ansible-role-nodejs/issues/175
Debian has changed the repository urls and it is failing. 